### PR TITLE
Bind click handler to save button

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -68,6 +68,12 @@ $(document).ready(function() {
     getSavedTartget(targetEmailAddress, renderPanels);
   });
 
+
+  // Function that binds click event handlers to save butotns on dynamically created panels
+  $("div#contact-area").on("click", "a.save", event => {
+    console.log(event);
+  });
+
   function getSavedTartget(targetEmail, render) {
     $.get(`api/savedsearch/${targetEmail}`).done(targetResponse => {
       render(targetResponse);
@@ -148,7 +154,7 @@ $(document).ready(function() {
           <h3 class="panel-title" style="display:inline-block">${
             targetResponse.target.name
           }</h3>
-          <a href="#"><i class="glyphicon glyphicon-floppy-save pull-right"></i></a>
+          <a href="#" class="save"><i class="glyphicon glyphicon-floppy-save pull-right"></i></a>
 				</div>
 				<div class="panel-body">
           <div class="list-group">


### PR DESCRIPTION
Added click handler to the save icons. The click only logs the click-event to the console. We ran out of credits for the Clearbit API, so I haven't implemented the save feature.